### PR TITLE
Fix error when visualizing destination

### DIFF
--- a/Traveler.js
+++ b/Traveler.js
@@ -47,7 +47,7 @@ class Traveler {
         let travelData = creep.memory._trav;
         let state = this.deserializeState(travelData, destination);
         // uncomment to visualize destination
-        // this.circle(destination.pos, "orange");
+        // this.circle(destination, "orange");
         // check if creep is stuck
         if (this.isStuck(creep, state)) {
             state.stuckCount++;

--- a/Traveler.ts
+++ b/Traveler.ts
@@ -60,7 +60,7 @@ export class Traveler {
         let state = this.deserializeState(travelData, destination);
 
         // uncomment to visualize destination
-        // this.circle(destination.pos, "orange");
+        // this.circle(destination, "orange");
 
         // check if creep is stuck
         if (this.isStuck(creep, state)) {


### PR DESCRIPTION
Fixes an erroneous .pos passing the wrong object to .circle().

Fixes #1 