### PR TITLE
Add room-level granularity to [structure|creep]MatrixTick

### DIFF
--- a/Traveler.js
+++ b/Traveler.js
@@ -398,8 +398,9 @@ class Traveler {
      * @returns {any}
      */
     static getStructureMatrix(room, freshMatrix) {
-        if (!this.structureMatrixCache[room.name] || (freshMatrix && Game.time !== this.structureMatrixTick)) {
-            this.structureMatrixTick = Game.time;
+        if (!this.structureMatrixTick) this.structureMatrixTick = {};
+        if (!this.structureMatrixCache[room.name] || (freshMatrix && Game.time !== this.structureMatrixTick[room.name])) {
+            this.structureMatrixTick[room.name] = Game.time;
             let matrix = new PathFinder.CostMatrix();
             this.structureMatrixCache[room.name] = Traveler.addStructuresToMatrix(room, matrix, 1);
         }
@@ -411,8 +412,9 @@ class Traveler {
      * @returns {any}
      */
     static getCreepMatrix(room) {
-        if (!this.creepMatrixCache[room.name] || Game.time !== this.creepMatrixTick) {
-            this.creepMatrixTick = Game.time;
+        if (!this.creepMatrixTick) this.creepMatrixTick = {};
+        if (!this.creepMatrixCache[room.name] || Game.time !== this.creepMatrixTick[room.name]) {
+            this.creepMatrixTick[room.name] = Game.time;
             this.creepMatrixCache[room.name] = Traveler.addCreepsToMatrix(room, this.getStructureMatrix(room, true).clone());
         }
         return this.creepMatrixCache[room.name];

--- a/Traveler.ts
+++ b/Traveler.ts
@@ -7,8 +7,8 @@ export class Traveler {
 
     private static structureMatrixCache: {[roomName: string]: CostMatrix} = {};
     private static creepMatrixCache: {[roomName: string]: CostMatrix} = {};
-    private static creepMatrixTick: number;
-    private static structureMatrixTick: number;
+    private static creepMatrixTick: {[roomName: string]: number} = {};
+    private static structureMatrixTick: {[roomName: string]: number} = {};
 
     /**
      * move creep to destination
@@ -458,8 +458,8 @@ export class Traveler {
      */
 
     public static getStructureMatrix(room: Room, freshMatrix?: boolean): CostMatrix {
-        if (!this.structureMatrixCache[room.name] || (freshMatrix && Game.time !== this.structureMatrixTick)) {
-            this.structureMatrixTick = Game.time;
+        if (!this.structureMatrixCache[room.name] || (freshMatrix && Game.time !== this.structureMatrixTick[room.name])) {
+            this.structureMatrixTick[room.name] = Game.time;
             let matrix = new PathFinder.CostMatrix();
             this.structureMatrixCache[room.name] = Traveler.addStructuresToMatrix(room, matrix, 1);
         }
@@ -473,8 +473,8 @@ export class Traveler {
      */
 
     public static getCreepMatrix(room: Room) {
-        if (!this.creepMatrixCache[room.name] || Game.time !== this.creepMatrixTick) {
-            this.creepMatrixTick = Game.time;
+        if (!this.creepMatrixCache[room.name] || Game.time !== this.creepMatrixTick[room.name]) {
+            this.creepMatrixTick[room.name] = Game.time;
             this.creepMatrixCache[room.name] = Traveler.addCreepsToMatrix(room,
                 this.getStructureMatrix(room, true).clone());
         }


### PR DESCRIPTION
The current shard-level cache invalidation strategy fails when multiple rooms need a matrix recalculated. The first room to need a new matrix gets one, but subsequent rooms that need a new matrix in the same tick are stuck with a cached result that should be invalidated but won't be, because all rooms are sharing the same invalidation variable. This change gives each room its own cache invalidation variable.